### PR TITLE
Fix kv syntax

### DIFF
--- a/functions/formatkv.pp
+++ b/functions/formatkv.pp
@@ -15,7 +15,7 @@ function systemd::formatkv($section,$h) {
   #
   $directives = $h.reduce('') |$memo,$v| {
     $s = [$v[1]].flatten.filter |$a| { !empty($a) }.join(' ')
-    empty($s) ? { false => "${memo}\n${v[0]} = ${s}", true => $memo }
+    empty($s) ? { false => "${memo}\n${v[0]}=${s}", true => $memo }
   }
 
   if empty($directives) { return('') }

--- a/functions/formatkv.pp
+++ b/functions/formatkv.pp
@@ -1,0 +1,25 @@
+#
+## Helper function that turns a section + key-value hash into
+## systemd.unit section directives.
+##
+## Notes:
+##   The section header is included in the output
+##   Empty values are filtered out
+##   Values of type ARRAY are converted to a space-separated string
+#
+function systemd::formatkv($section,$h) {
+
+  #
+  ## Output section header and append one directive for each KV pair in
+  ## the hash. Note: if hash is empty, no output is produced
+  #
+  $directives = $h.reduce('') |$memo,$v| {
+    $s = [$v[1]].flatten.filter |$a| { !empty($a) }.join(' ')
+    empty($s) ? { false => "${memo}\n${v[0]} = ${s}", true => $memo }
+  }
+
+  if empty($directives) { return('') }
+
+  "[${section}]${directives}"
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,29 +24,3 @@ class systemd {
   }
 
 }
-
-#
-## Helper function that turns a section + key-value hash into
-## systemd.unit section directives.
-##
-## Notes:
-##   The section header is included in the output
-##   Empty values are filtered out
-##   Values of type ARRAY are converted to a space-separated string
-#
-function systemd::formatkv($section,$h) {
-
-  #
-  ## Output section header and append one directive for each KV pair in
-  ## the hash. Note: if hash is empty, no output is produced
-  #
-  $directives = $h.reduce('') |$memo,$v| {
-    $s = [$v[1]].flatten.filter |$a| { !empty($a) }.join(' ')
-    empty($s) ? { false => "${memo}\n${v[0]} = ${s}", true => $memo }
-  }
-
-  if empty($directives) { return('') }
-
-  "[${section}]${directives}"
-
-}


### PR DESCRIPTION
The `systemd.syntax(7)` man page doesn't mention spaces around `=` in the unit files, and it seems like it's not supported. Here's a snippet from the man page:

> Each file is a plain text file divided into sections, with configuration entries in the style key=value. Empty lines and lines starting with "#" or ";" are ignored, which may be used for commenting.

This PR removes the spaces around `=` and moves the `formatkv` function to its own file.